### PR TITLE
3주차 문제풀이 

### DIFF
--- a/prob3.cpp
+++ b/prob3.cpp
@@ -12,26 +12,26 @@ vector<vector<int>> dist; //현재 칸까지 이동한 거리를 기록
 queue<pair<int, int>> q;
 
 void BFS(int x, int y)
-{
-    visited[x][y] = 1;
-    dist[x][y] = 1;
+{ 
+    visited[x][y] = 1; //시작위치 방문했음을 표시
+    dist[x][y] = 1; //시작위치 
     q.push(make_pair(x, y));
     while (!q.empty())
     {
-        int X = q.front().first;
-        int Y = q.front().second;
+        int X = q.front().first; //큐의 맨 앞에 X좌표 저장
+        int Y = q.front().second; //큐의 맨 앞에 Y좌표 저장
         q.pop();
         for (int i = 0; i < 4; i++) //다음 이동할 칸을 큐에 넣기
         {
-            int next_x = X + moving[i][0];
+            int next_x = X + moving[i][0]; //상하좌우에서 이동 가능한 칸 찾기
             int next_y = Y + moving[i][1];
             if (0 <= next_x && next_x < N && 0 <= next_y && next_y < M)// 0 <= x < N, 0 <= y < M  
             {
                 if (arr[next_x][next_y] == 1 && visited[next_x][next_y] == 0)
                 { //방문한적 없는 칸이고, 미로의 이동할 수 있는 칸
                     q.push(make_pair(next_x, next_y));
-                    visited[next_x][next_y] = 1;
-                    dist[next_x][next_y] = dist[X][Y] + 1;
+                    visited[next_x][next_y] = 1; //방문했음 표시
+                    dist[next_x][next_y] = dist[X][Y] + 1; //이 칸까지 오는데 걸리는 최소 거리
                 }
             }
         }


### PR DESCRIPTION
https://www.acmicpc.net/problem/2178

미로탐색 문제입니다.

이번에도 이 형식으로 코드를 짤 생각입니다.
입력: n, m 배열 입력받기 
함수: BFS 사용
출력: (1,1) -> (N,M)으로 이동할 때 
지나야하는 최소의 칸 수

![image](https://github.com/user-attachments/assets/0266c987-7ff7-41b2-9d74-af6faec10a0a)
입력은 1주차 때 풀었던 문제에서  N*M으로 바꾸기만 하면 완성입니다. 

처음엔 
DFS로 미로 탐색을 하고 0,0부터 N,M까지의 최소 거리를  반환하는 형식으로 문제를 풀려고 했다.

하지만 N,M에 도착했을 때 최소거리를 반환하고 함수를 끝내야하는데 재귀함수로 구현하다보니 꼬였다. 
![image](https://github.com/user-attachments/assets/2d729864-08eb-4fed-aba4-8b6f1a64a088)
이런 케이스를 처리할 때
내가 만든 알고리즘으로는 둘 중 하나의 경로로 도착하는 거리를 출력했는데
아래로 가는 경우와 오른쪽으로 가는 경우를 모두 구해서 둘 중 짧은 거로 처리 해야 맞는 답이 나오므로
알고리즘을 수정해야 한다.
하지만 두 갈래길 이 아니라 몇 십 갈래 길 을 처리해야할 수 도 있기 때문에 DFS로 풀 엄두가 안나서 BFS로 풀기로 결정했다.

BFS로 구현을 하다보니 아직 어떻게 구현해야 할 지 감이 제대로 안잡혀있어서  (BFS에 약한 거 같다)
거리를 어떻게 반환해야 할지도 막막했고 어디서 큐를 비우고 큐의 값을 받아와야할 지 정말 막막했다.
결국 블로그의 도움을 받았다. 
https://wooono.tistory.com/410

![image](https://github.com/user-attachments/assets/dab02b8c-6a85-4f9b-bc57-afe50879448a)

알고리즘은 요약하자면
1. 처음 시작좌표를 큐에 넣는다.

2. 큐에 들어간 원소를 빼내서 상하좌우 칸이 이동가능한 지 확인한다.
3. 이동가능한 칸을 큐에 추가하고 방문했음을 표시한다. 
4. 큐에서 빼낸 원소의 칸까지의 거리에 +1을 하여 이동한 칸까지의 거리를 표시한다. 
5. 2-3-4를 반복하여 모든 칸을 탐색한다. 

N,M 도착하는 경우의 수가 존재하는 데이터만 입력으로 주어진다고 했으므로

dist[N-1][M-1]칸의 데이터를 출력하면 정답이 나온다. 

자세한 설명은 블로그를 참고해주세요.
